### PR TITLE
Build against libsodium 1.0.18

### DIFF
--- a/Sodium.xs
+++ b/Sodium.xs
@@ -1988,7 +1988,7 @@ encrypt(self, msg, adata, nonce, key)
         unsigned int nonce_size;
         unsigned int adlen_size;
         unsigned int key_size;
-        int (*encrypt_function)(unsigned char *, unsigned long long *, const unsigned char *, unsigned long long, 
+        int (*encrypt_function)(unsigned char *, unsigned long long *, const unsigned char *, unsigned long long,
             const unsigned char *, unsigned long long, const unsigned char *, const unsigned char *, const unsigned char *);
         DataBytesLocker *bl;
     PPCODE:
@@ -2074,7 +2074,7 @@ decrypt(self, msg, adata, nonce, key)
         unsigned int nonce_size;
         unsigned int adlen_size;
         unsigned int key_size;
-        int (*decrypt_function)(unsigned char *, unsigned long long *, unsigned char *, const unsigned char *, unsigned long long, 
+        int (*decrypt_function)(unsigned char *, unsigned long long *, unsigned char *, const unsigned char *, unsigned long long,
             const unsigned char *, unsigned long long, const unsigned char *, const unsigned char *);
         DataBytesLocker *bl;
     PPCODE:
@@ -4535,14 +4535,22 @@ SALSA20_KEYBYTES(...)
 unsigned int
 AES128CTR_NONCEBYTES(...)
     CODE:
+#ifdef crypto_stream_aes128ctr_NONCEBYTES
         RETVAL = crypto_stream_aes128ctr_NONCEBYTES;
+#else
+        croak("aes128ctr is not supported by your version of libsodium");
+#endif
     OUTPUT:
         RETVAL
 
 unsigned int
 AES128CTR_KEYBYTES(...)
     CODE:
+#ifdef crypto_stream_aes128ctr_KEYBYTES
         RETVAL = crypto_stream_aes128ctr_KEYBYTES;
+#else
+        croak("aes128ctr is not supported by your version of libsodium");
+#endif
     OUTPUT:
         RETVAL
 
@@ -4570,7 +4578,11 @@ keygen(self)
                 key_size = crypto_stream_salsa20_KEYBYTES;
                 break;
             case 3:
+#ifdef crypto_stream_aes128ctr_KEYBYTES
                 key_size = crypto_stream_aes128ctr_KEYBYTES;
+#else
+                croak("aes128ctr is not supported by your version of libsodium");
+#endif
                 break;
             default:
                 key_size = crypto_stream_KEYBYTES;
@@ -4605,7 +4617,11 @@ nonce(self, ...)
                 nonce_size = crypto_stream_salsa20_NONCEBYTES;
                 break;
             case 3:
+#ifdef crypto_stream_aes128ctr_KEYBYTES
                 nonce_size = crypto_stream_aes128ctr_NONCEBYTES;
+#else
+                croak("aes128ctr is not supported by your version of libsodium");
+#endif
                 break;
             case 4:
                 nonce_size = crypto_stream_chacha20_IETF_NONCEBYTES;
@@ -4687,9 +4703,13 @@ bytes(self, length, nonce, key)
                 bytes_function = &crypto_stream_salsa20;
                 break;
             case 3:
+#ifdef crypto_stream_aes128ctr_KEYBYTES
                 nonce_size = crypto_stream_aes128ctr_NONCEBYTES;
                 key_size = crypto_stream_aes128ctr_KEYBYTES;
                 bytes_function = &crypto_stream_aes128ctr;
+#else
+                croak("aes128ctr is not supported by your version of libsodium");
+#endif
                 break;
             case 4:
                 nonce_size = crypto_stream_salsa20_NONCEBYTES;
@@ -4777,9 +4797,13 @@ xor(self, msg, nonce, key)
                 xor_function = &crypto_stream_salsa20_xor;
                 break;
             case 3:
+#ifdef crypto_stream_aes128ctr_KEYBYTES
                 nonce_size = crypto_stream_aes128ctr_NONCEBYTES;
                 key_size = crypto_stream_aes128ctr_KEYBYTES;
                 xor_function = &crypto_stream_aes128ctr_xor;
+#else
+                croak("aes128ctr is not supported by your version of libsodium");
+#endif
                 break;
             case 4:
                 nonce_size = crypto_stream_salsa20_NONCEBYTES;

--- a/Sodium.xs
+++ b/Sodium.xs
@@ -2474,7 +2474,7 @@ keypair(self, ...)
                 unsigned char * seed_buf = (unsigned char *)SvPV(ST(1), seed_len);
 
                 if ( seed_len != crypto_box_SEEDBYTES ) {
-                    croak("Invalid seed length: %u", seed_len);
+                    croak("Invalid seed length: %"UVf, (UV)seed_len);
                 }
 
                 blp = InitDataBytesLocker(aTHX_ crypto_box_PUBLICKEYBYTES);
@@ -3061,7 +3061,7 @@ keypair(self, ...)
                 unsigned char * seed_buf = (unsigned char *)SvPV(ST(1), seed_len);
 
                 if ( seed_len != crypto_sign_SEEDBYTES ) {
-                    croak("Invalid seed length: %u", seed_len);
+                    croak("Invalid seed length: %"UVf, (UV)seed_len);
                 }
 
                 blp = InitDataBytesLocker(aTHX_ crypto_sign_PUBLICKEYBYTES);
@@ -3419,7 +3419,7 @@ keygen(self, keybytes = crypto_generichash_KEYBYTES)
         PERL_UNUSED_VAR(self);
 
         if ( keybytes < crypto_generichash_KEYBYTES_MIN || keybytes > crypto_generichash_KEYBYTES_MAX ) {
-            croak("Invalid keybytes value: %u", keybytes);
+            croak("Invalid keybytes value: %"UVf, (UV)keybytes);
         }
 
         bl = InitDataBytesLocker(aTHX_ keybytes);
@@ -3459,13 +3459,13 @@ mac(self, msg, ...)
                 if ( keylen == 3 && strnEQ(key, "key", 3) ) {
                     key_buf = (unsigned char *)SvPV(ST(i+1), key_len);
                     if ( key_len < crypto_generichash_KEYBYTES_MIN || key_len > crypto_generichash_KEYBYTES_MAX ) {
-                        croak("Invalid key length: %u", key_len);
+                        croak("Invalid key length: %"UVf, (UV)key_len);
                     }
                 }
                 else if ( keylen == 5 && strnEQ(key, "bytes", 5) ) {
                     bytes = (size_t)SvUV(ST(i+1));
                     if ( bytes < crypto_generichash_BYTES_MIN || bytes > crypto_generichash_BYTES_MAX ) {
-                        croak("Invalid bytes value: %u", bytes);
+                        croak("Invalid bytes value: %"UVf, (UV)bytes);
                     }
                 } else {
                     croak("Invalid argument: %s", key);
@@ -3509,13 +3509,13 @@ init(self, ...)
                 if ( keylen == 3 && strnEQ(key, "key", 3) ) {
                     key_buf = (unsigned char *)SvPV(ST(i+1), key_len);
                     if ( key_len < crypto_generichash_KEYBYTES_MIN || key_len > crypto_generichash_KEYBYTES_MAX ) {
-                        croak("Invalid key length: %u", key_len);
+                        croak("Invalid key length: %"UVf, (UV)key_len);
                     }
                 }
                 else if ( keylen == 5 && strnEQ(key, "bytes", 5) ) {
                     bytes =  SvUV(ST(i+1));
                     if ( bytes < crypto_generichash_BYTES_MIN || bytes > crypto_generichash_BYTES_MAX ) {
-                        croak("Invalid bytes value: %u", bytes);
+                        croak("Invalid bytes value: %"UVf, (UV)bytes);
                     }
                 } else {
                     croak("Invalid argument: %s", key);
@@ -3599,7 +3599,7 @@ final(self, ...)
                 if ( keylen == 5 && strnEQ(key, "bytes", 5) ) {
                     bytes =  SvUV(ST(i+1));
                     if ( bytes < crypto_generichash_BYTES_MIN || bytes > crypto_generichash_BYTES_MAX ) {
-                        croak("Invalid bytes value: %u", bytes);
+                        croak("Invalid bytes value: %"UVf, (UV)bytes);
                     }
                 } else {
                     croak("Invalid argument: %s", key);
@@ -3799,9 +3799,9 @@ key(self, passphrase, salt, ... )
                         croak("Invalid opslimit: %lld", opslimit);
                     }
                 } else if ( keylen == 8 && strnEQ(key, "memlimit", 8) ) {
-                    memlimit = (unsigned long long)SvUV(ST(i+1));
+                    memlimit = (size_t)SvUV(ST(i+1));
                     if ( memlimit < 1 ) {
-                        croak("Invalid memlimit: %lld", memlimit);
+                        croak("Invalid memlimit: %zu", memlimit);
                     }
                 } else if ( keylen == 5 && strnEQ(key, "bytes", 5) ) {
                     outlen = (unsigned long long)SvUV(ST(i+1));
@@ -3866,7 +3866,7 @@ str(self, passphrase, ... )
                 } else if ( keylen == 8 && strnEQ(key, "memlimit", 8) ) {
                     memlimit =  SvUV(ST(i+1));
                     if ( memlimit < 1 ) {
-                        croak("Invalid memlimit: %lld", memlimit);
+                        croak("Invalid memlimit: %zu", memlimit);
                     }
                 } else {
                     croak("Invalid argument: %s", key);
@@ -5249,7 +5249,7 @@ _overload_str(self, ...)
             croak("Unlock BytesLocker object before accessing the data");
         }
 
-        pv = newSVpvn((unsigned char *)sbl->bytes, sbl->length);
+        pv = newSVpvn((const char *)sbl->bytes, sbl->length);
         SvREADONLY_on(pv);
 
         mXPUSHs(pv);
@@ -5398,7 +5398,7 @@ bytes(self)
             croak("Unlock BytesLocker object before accessing the data");
         }
 
-        pv = newSVpvn((unsigned char *)sbl->bytes, sbl->length);
+        pv = newSVpvn((const char *)sbl->bytes, sbl->length);
 
         mXPUSHs(pv);
     }

--- a/t/example_stream.t
+++ b/t/example_stream.t
@@ -93,9 +93,11 @@ my $msg = "Secret message";
     is($decrypted_msg->to_hex, bin2hex($msg), "msg decrypted");
 }
 
-{
+SKIP: {
     ## AES-128-CTR
     ########
+    skip("libsodium version does not support aes128ctr")
+        unless eval { $crypto_stream->AES128CTR_KEYBYTES; 1 };
 
     my ($key, $nonce, $random_bytes, $secret, $decrypted_msg);
 

--- a/t/stream.t
+++ b/t/stream.t
@@ -8,9 +8,14 @@ use Crypt::NaCl::Sodium qw(bin2hex);
 
 my $crypto_stream = Crypt::NaCl::Sodium->stream();
 
+my $aes128_ok = eval {
+    $crypto_stream->AES128CTR_NONCEBYTES;
+    1;
+};
+
 ok($crypto_stream->$_ > 0, "$_ > 0")
     for qw( NONCEBYTES KEYBYTES CHACHA20_NONCEBYTES CHACHA20_KEYBYTES
-    SALSA20_NONCEBYTES SALSA20_KEYBYTES AES128CTR_NONCEBYTES AES128CTR_KEYBYTES  );
+    SALSA20_NONCEBYTES SALSA20_KEYBYTES), $aes128_ok ?  qw( AES128CTR_NONCEBYTES AES128CTR_KEYBYTES  ) : ();
 
 my %tests = (
     'XSalsa20' => {
@@ -33,6 +38,8 @@ my %tests = (
         const_prefix => 'AES128CTR_',
     },
 );
+
+delete $tests{'AES-128-CTR'} unless $aes128_ok;
 
 my $msg = chr(0x42) x 160;
 


### PR DESCRIPTION
Tried building this against libsodium 1.0.18, and ran into a couple of issues:

1. aes128ctr has been dropped
2. hex2bin() behavior has changed fairly drastically
3. compiler warnings

(pull request outgrew its original branch name :P)